### PR TITLE
bug fix for test

### DIFF
--- a/base58/base58_test.go
+++ b/base58/base58_test.go
@@ -19,8 +19,8 @@ func initTestPairs() {
 		return
 	}
 	// pre-make the test pairs, so it doesn't take up benchmark time...
-	data := make([]byte, 32)
 	for i := 0; i < n; i++ {
+		data := make([]byte, 32)
 		rand.Read(data)
 		testPairs = append(testPairs, testValues{dec: data, enc: FastBase58Encoding(data)})
 	}

--- a/base58_test.go
+++ b/base58_test.go
@@ -19,8 +19,8 @@ func initTestPairs() {
 		return
 	}
 	// pre-make the test pairs, so it doesn't take up benchmark time...
-	data := make([]byte, 32)
 	for i := 0; i < n; i++ {
+		data := make([]byte, 32)
 		rand.Read(data)
 		testPairs = append(testPairs, testValues{dec: data, enc: FastBase58Encoding(data)})
 	}


### PR DESCRIPTION
In base58/base58_test.go line 22 make a byte array to use as random data container.
But in the whole loop, data is never change and point to same slice, but in line 25 data is assigned to a new `testValues`. So all the `testValues`'s field `dec` point to the same slice. So all the encode benchmark use a same slice in their whole loop. I think this does not match the intended purpose.

https://github.com/mr-tron/base58/blob/89529c6904fcd077434931b4eac8b4b2f0991baf/base58_test.go#L22