### PR TITLE
Simplify decoding (no functional changes)

### DIFF
--- a/base58.go
+++ b/base58.go
@@ -131,20 +131,24 @@ func FastBase58DecodingAlphabet(str string, alphabet *Alphabet) ([]byte, error) 
 		mask = 32
 	}
 	mask -= 8
-	var j, cnt int
-	for j, cnt = 0, 0; j < len(outi); j++ {
+
+	outLen := 0
+	for j := 0; j < len(outi); j++ {
 		for mask < 32 { // loop relies on uint overflow
-			binu[cnt] = byte(outi[j] >> mask)
+			binu[outLen] = byte(outi[j] >> mask)
 			mask -= 8
-			cnt++
+			outLen++
 		}
 		mask = 24
 	}
 
-	for n := zcount; n < len(binu); n++ {
-		if binu[n] > 0 {
-			return binu[n-zcount : cnt], nil
+	// find the most significant byte post-decode, if any
+	for msb := zcount; msb < len(binu); msb++ {
+		if binu[msb] > 0 {
+			return binu[msb-zcount : outLen], nil
 		}
 	}
-	return binu[:cnt], nil
+
+	// it's all zeroes
+	return binu[:outLen], nil
 }

--- a/base58.go
+++ b/base58.go
@@ -120,7 +120,7 @@ func FastBase58DecodingAlphabet(str string, alphabet *Alphabet) ([]byte, error) 
 
 		for j := len(outi) - 1; j >= 0; j-- {
 			t = uint64(outi[j])*58 + c
-			c = (t >> 32) & 0x3f
+			c = t >> 32
 			outi[j] = uint32(t & 0xffffffff)
 		}
 	}

--- a/base58.go
+++ b/base58.go
@@ -104,8 +104,9 @@ func FastBase58DecodingAlphabet(str string, alphabet *Alphabet) ([]byte, error) 
 
 	var t, c uint64
 
+	// the 32bit algo stretches the result up to 2 times
+	binu := make([]byte, 2*((b58sz*406/555)+1))
 	outi := make([]uint32, (b58sz+3)/4)
-	binu := make([]byte, (b58sz+3)*3)
 
 	for _, r := range str {
 		if r > 127 {


### PR DESCRIPTION
Hi! It looks like the original implementation back in https://github.com/trezor/trezor-crypto/commit/89a7d7797b806fac left a few too many sanity checks in the source. Adjusted and simplified to appease the go compiler.

Thank you for the excellent starting base, and the extensive test suite!

* Before
```
base58$ go test -bench=. -count=1 -benchmem ./
goos: darwin
goarch: amd64
pkg: github.com/mr-tron/base58
BenchmarkTrivialBase58Encoding-8   	  182612	      7054 ns/op	    1911 B/op	      90 allocs/op
BenchmarkFastBase58Encoding-8      	  928771	      1245 ns/op	     144 B/op	       2 allocs/op
BenchmarkTrivialBase58Decoding-8   	  359553	      3370 ns/op	     513 B/op	      48 allocs/op
BenchmarkFastBase58Decoding-8      	 1558393	       838 ns/op	     368 B/op	       3 allocs/op
PASS
ok  	github.com/mr-tron/base58	58.666s
```

* After ( when including https://github.com/mr-tron/base58/pull/15 )

```
base58$ go test -bench=. -count=1 -benchmem ./
goos: darwin
goarch: amd64
pkg: github.com/mr-tron/base58
BenchmarkTrivialBase58Encoding-8   	  155588	      7466 ns/op	    1911 B/op	      90 allocs/op
BenchmarkFastBase58Encoding-8      	  966726	      1245 ns/op	      96 B/op	       2 allocs/op
BenchmarkTrivialBase58Decoding-8   	  350648	      3447 ns/op	     513 B/op	      48 allocs/op
BenchmarkFastBase58Decoding-8      	 2276010	       523 ns/op	     127 B/op	       2 allocs/op
PASS
ok  	github.com/mr-tron/base58	57.326s
```

/cc @prusnak @Stebalien 