### PR TITLE
Simplify encoding (no functional changes)

### DIFF
--- a/base58.go
+++ b/base58.go
@@ -54,10 +54,11 @@ func FastBase58EncodingAlphabet(bin []byte, alphabet *Alphabet) string {
 		high = i
 	}
 
-	for i = 0; i < size && out[i] == 0; i++ {
+	// Determine the additional "zero-gap" in the buffer (aside from zcount)
+	for i = zcount; i < size && out[i] == 0; i++ {
 	}
 
-	// Use the first half for the result
+	// Now encode the values with actual alphabet in-place
 	val := out[i-zcount:]
 	size = len(val)
 	for i = 0; i < size; i++ {

--- a/base58.go
+++ b/base58.go
@@ -61,11 +61,7 @@ func FastBase58EncodingAlphabet(bin []byte, alphabet *Alphabet) string {
 	val := out[i-zcount:]
 	size = len(val)
 	for i = 0; i < size; i++ {
-		if i < zcount {
-			out[i] = alphabet.encode[0]
-		} else {
-			out[i] = alphabet.encode[val[i]]
-		}
+		out[i] = alphabet.encode[val[i]]
 	}
 
 	return string(out[:size])


### PR DESCRIPTION
Reduce work-buffer alocation size to the absolute minimum. Unlike my other PR this does not change the performance at all ( it stays virtually the same ). Rather the allocation is halved, specifically https://github.com/ribasushi/base58/commit/505011d34545eb060ec69be9ab0e14c19db6e48b#diff-20a30baf90cfb9bb539a06cf6ecebcd1L36-R41

Cheers!
